### PR TITLE
Move properties to methods

### DIFF
--- a/liesym/__init__.py
+++ b/liesym/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     if os.environ.get("SPHINX_BUILD") != "1":
         raise
     else:
-        _LieAlgebraBackend=""
+        _LieAlgebraBackend = ""
 
 from .groups import *
 from .algebras import *
@@ -36,5 +36,5 @@ __all__ = [
     "Group",
     "LieGroup",
     "Z",
-    "root_angle"
+    "root_angle",
 ]

--- a/liesym/algebras/_backend.py
+++ b/liesym/algebras/_backend.py
@@ -1,14 +1,7 @@
 import numpy as np
-from numpy.lib.arraysetops import isin
-from sympy import flatten, Matrix, Rational
+from sympy import flatten, Matrix, Rational, sympify
 
 from .. import _LieAlgebraBackend
-
-
-def _annotate(M: Matrix, basis: str) -> Matrix:
-    """Adds basis attribute to sympy.Matrix"""
-    setattr(M, "basis", basis)
-    return M
 
 
 def _to_rational_tuple(obj):
@@ -77,7 +70,7 @@ def _rust_wrapper(func=None, default=None):
         if len(shape) == 1:
             shape = (shape[0], 1) if rank == 1 else (1, shape[0])
 
-        m = Matrix(*shape, plain_values)
+        m = sympify(Matrix(*shape, plain_values))
         return [m.row(i) for i in range(m.shape[0])]
 
     return inner
@@ -135,7 +128,7 @@ def create_backend(algebra):
     return _LieAlgebraBackendWrapped(
         algebra.rank,
         algebra.n_pos_roots,
-        algebra.simple_roots,
+        algebra.simple_roots(),
         algebra.cartan_matrix.pinv(),
         algebra.omega_matrix,
         algebra.omega_matrix.pinv(),

--- a/liesym/algebras/_classic.py
+++ b/liesym/algebras/_classic.py
@@ -15,7 +15,7 @@ def _euclidean_root(i, n):
 
 
 class A(LieAlgebra):
-    r"""The compact lie group of type A. The dynkin diagram for this algebra is
+    r"""The compact lie algebra of type A. The dynkin diagram for this algebra is
 
     .. image:: ../../docs/source/images/type_A.png
        :width: 300px
@@ -23,13 +23,21 @@ class A(LieAlgebra):
 
     """
 
-    def __new__(cls, n):
-        return super().__new__(cls, "A", _sympify(n))
+    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+        """Creates the A algebra of rank `n`
 
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        n = self.rank
-        self._simple_roots = [_euclidean_root(i, n + 1) for i in range(n)]
+        Args:
+            n (int): Dimension of algbera
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
+
+        """
+        return super().__new__(
+            cls,
+            "A",
+            _sympify(n),
+            simple_roots or [_euclidean_root(i, n + 1) for i in range(n)],
+        )
 
     @property
     def dimension(self) -> int:
@@ -60,7 +68,7 @@ class A(LieAlgebra):
                 return self._dim_name_fmt(6)
             elif irrep == Matrix([[0, 2]]):
                 return self._dim_name_fmt(6, True)
-        return super().dim_name(irrep, basis)
+        return super().dim_name(irrep, basis="omega")
 
     def max_dynkin_digit(self, irrep: Matrix) -> int:
         """Returns the max Dynkin Digit for the representation"""
@@ -82,13 +90,21 @@ class B(LieAlgebra):
 
     """
 
-    def __new__(cls, n):
-        return super().__new__(cls, "B", _sympify(n))
+    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+        """Creates the B algebra of dimension `n`
 
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        n = self.rank
-        self._simple_roots = [_euclidean_root(i, n) for i in range(n)]
+        Args:
+            n (int): Dimension of algbera
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
+
+        """
+        return super().__new__(
+            cls,
+            "B",
+            _sympify(n),
+            simple_roots or [_euclidean_root(i, n) for i in range(n)],
+        )
 
     def max_dynkin_digit(self, irrep: Matrix) -> int:
         """Returns the max Dynkin Digit for the representation"""
@@ -125,17 +141,23 @@ class C(LieAlgebra):
        :align: center
     """
 
-    def __new__(cls, n):
-        return super().__new__(cls, "C", _sympify(n))
+    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+        """Creates the C algebra of dimension `n`
 
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        n = self.rank
-        c_root = [0] * n
-        c_root[-1] = 2
-        self._simple_roots = [_euclidean_root(i, n) for i in range(n - 1)] + [
-            Matrix([c_root])
-        ]
+        Args:
+            n (int): Dimension of algbera
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
+
+        """
+        if simple_roots is None:
+            c_root = [0] * n
+            c_root[-1] = 2
+            simple_roots = [_euclidean_root(i, n) for i in range(n - 1)] + [
+                Matrix([c_root])
+            ]
+
+        return super().__new__(cls, "C", _sympify(n), simple_roots)
 
     def max_dynkin_digit(self, irrep: Matrix) -> int:
         """Returns the max Dynkin Digit for the representation"""
@@ -173,20 +195,26 @@ class D(LieAlgebra):
        :align: center
     """
 
-    def __new__(cls, n):
+    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+        """Creates the D algebra of dimension `n`
+
+        Args:
+            n (int): Dimension of algbera
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
+
+        """
         if n < 2:
             raise ValueError("Min dimension for type 'D' is 2")
-        return super().__new__(cls, "D", _sympify(n))
+        if simple_roots is None:
+            d_root = [0] * n
+            d_root[-1] = 1
+            d_root[-2] = 1
+            simple_roots = [_euclidean_root(i, n) for i in range(n - 1)] + [
+                Matrix([d_root])
+            ]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        n = self.rank
-        d_root = [0] * n
-        d_root[-1] = 1
-        d_root[-2] = 1
-        self._simple_roots = [_euclidean_root(i, n) for i in range(n - 1)] + [
-            Matrix([d_root])
-        ]
+        return super().__new__(cls, "D", _sympify(n), simple_roots)
 
     def max_dynkin_digit(self, irrep: Matrix) -> int:
         """Returns the max Dynkin Digit for the representation"""

--- a/liesym/algebras/_exceptionals.py
+++ b/liesym/algebras/_exceptionals.py
@@ -1,5 +1,5 @@
-from sympy import flatten, Matrix, S, sympify
-
+from sympy import flatten, Matrix, S
+from sympy.core.sympify import _sympify
 from ._base import LieAlgebra
 
 
@@ -11,18 +11,25 @@ class F4(LieAlgebra):
        :align: center
 
     """
+    
+    def __new__(cls, simple_roots: "list[Matrix] | None" = None):
+        """Creates the F4 algebra
+        Args:
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
 
-    def __new__(cls):
-        return super().__new__(cls, "F", sympify(4))
-
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        self._simple_roots = [
+        """
+        return super().__new__(
+            cls,
+            "F",
+            _sympify(4),
+            simple_roots or [
             Matrix([[1, -1, 0, 0]]),
             Matrix([[0, 1, -1, 0]]),
             Matrix([[0, 0, 1, 0]]),
             Matrix([[-S.Half, -S.Half, -S.Half, -S.Half]]),
-        ]
+        ],
+        )
 
     @property
     def dimension(self) -> int:
@@ -46,13 +53,19 @@ class G2(LieAlgebra):
        :align: center
 
     """
+    def __new__(cls, simple_roots: "list[Matrix] | None" = None):
+        """Creates the G2 algebra
+        Args:
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
 
-    def __new__(cls):
-        return super().__new__(cls, "G", sympify(2))
-
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        self._simple_roots = [Matrix([[0, 1, -1]]), Matrix([[1, -2, 1]])]
+        """
+        return super().__new__(
+            cls,
+            "G",
+            _sympify(2),
+            simple_roots or [Matrix([[0, 1, -1]]), Matrix([[1, -2, 1]])]
+        )
 
     @property
     def dimension(self) -> int:
@@ -110,15 +123,24 @@ class E(LieAlgebra):
            E8
 
     """
+    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+        """Creates the E algebra of rank `n`
 
-    def __new__(cls, n):
+        Args:
+            n (int): Dimension of algbera
+            simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
+            calculating the algebra in a different basis. Defaults to None.
+
+        """
         if n not in [6, 7, 8]:
-            raise ValueError("Algebra series E only defined for 6, 7 and 8}")
-        return super().__new__(cls, "E", sympify(n))
+            raise ValueError("Algebra series E only defined for 6, 7 and 8")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        self._simple_roots = _e_series_default_roots(self.args[0])
+        return super().__new__(
+            cls,
+            "E",
+            _sympify(n),
+            simple_roots or _e_series_default_roots(n)
+        )
 
     @property
     def dimension(self) -> int:

--- a/liesym/groups/_base.py
+++ b/liesym/groups/_base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from functools import lru_cache
 
 from typing import Tuple, Union
@@ -323,11 +324,11 @@ class LieGroup(Group):
         Abstract
         """
         generators = self._calc_generator(**kwargs)
-        
+
         if cartan_only:
             return [x for x in generators if x.is_diagonal()]
         else:
             return generators
-        
+
     def _calc_generator(self, **_):
         raise NotImplementedError("This method needs calculation")

--- a/liesym/groups/_so.py
+++ b/liesym/groups/_so.py
@@ -26,7 +26,9 @@ class SO(LieGroup):
         else:
             self._algebra = B((n - 1) / 2)
 
-    def generators(self, cartan_only=False, indexed=False) -> list[Union[Matrix, Tuple[Matrix, tuple]]]:
+    def generators(
+        self, cartan_only=False, indexed=False
+    ) -> list[Union[Matrix, Tuple[Matrix, tuple]]]:
         """Generators for SO(N).
 
         Args:

--- a/liesym/groups/_su.py
+++ b/liesym/groups/_su.py
@@ -66,7 +66,7 @@ class SU(LieGroup):
         self._algebra = A(self.dimension - 1)
         self._generators = None
 
-    def generators(self, cartan_only=False,  **kwargs):
+    def generators(self, cartan_only=False, **kwargs):
         r"""Returns the generators representations of the group.
         Generators for SU(N). Based off the generalized Gell-Mann matrices $\lambda_a$
         the generators, $T_a$ are
@@ -80,6 +80,5 @@ class SU(LieGroup):
         """
         return super().generators(cartan_only=cartan_only, **kwargs)
 
-        
     def _calc_generator(self, **_):
         return [x / 2 for x in generalized_gell_mann(self.dimension)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ build-backend = "maturin"
 requires = ["maturin>=0.13,<0.14"]
 
 [tool.maturin]
-module-name="liesym._liesym_rust"
+module-name = "liesym._liesym_rust"
 features = ["pyo3/extension-module"]
 [project]
-authors = [{name = "Nathan Papapietro", email = "npapapietro95@gmail.com"}]
+authors = [{ name = "Nathan Papapietro", email = "npapapietro95@gmail.com" }]
 classifiers = [
   "Topic :: Scientific/Engineering :: Mathematics",
   "Topic :: Scientific/Engineering :: Physics",
@@ -28,11 +28,7 @@ Documentation = "https://npapapietro.github.io/liesym"
 Homepage = "https://github.com/npapapietro/liesym"
 
 [project.optional-dependencies]
-dev = [
-  "autopep8>=1.5.6",
-  "jupyter>=1.0.0",
-  "ufmt>=2.2.0"
-]
+dev = ["autopep8>=1.5.6", "jupyter>=1.0.0", "ufmt>=2.2.0", "mypy>=1.6.1"]
 docs = [
   "Sphinx>=4.1.1",
   "groundwork-sphinx-theme>=1.1.1",
@@ -44,7 +40,4 @@ test = ["pytest>=6.2.3"]
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
-testpaths = [
-  "tests",
-]
-pythonpath = ["liesym"]
+testpaths = ["tests"]

--- a/tests/test_algebra/test_backend.py
+++ b/tests/test_algebra/test_backend.py
@@ -11,7 +11,7 @@ def testBackendA():
     args = (
         algebra.rank,
         algebra.n_pos_roots,
-        algebra.simple_roots,
+        algebra.simple_roots(),
         algebra.cartan_matrix,
         algebra.cartan_matrix.pinv(),
         algebra.omega_matrix,
@@ -85,7 +85,7 @@ def testBackendBCD():
         args = (
             algebra.rank,
             algebra.n_pos_roots,
-            algebra.simple_roots,
+            algebra.simple_roots(),
             algebra.cartan_matrix,
             algebra.cartan_matrix.pinv(),
             algebra.omega_matrix,

--- a/tests/test_algebra/test_classic.py
+++ b/tests/test_algebra/test_classic.py
@@ -9,7 +9,7 @@ def test_A():
     assert A2.dimension == 3
     assert A2.n_pos_roots == 3
 
-    assert A2.simple_roots == [
+    assert A2.simple_roots() == [
         Matrix([[1, -1, 0]]),
         Matrix([[0, 1, -1]]),
     ]
@@ -17,12 +17,14 @@ def test_A():
     a = A2.to_alpha(Matrix([[1, -1, 0]]), "ortho")
     assert a == Matrix([[1, 0]]) and a.basis == Basis.ALPHA
 
+    A2.dim_name(Matrix([[1, -1, 0]]), basis="ortho")
+
     x = Matrix([[1, -1, 0]])
     x.basis = "ortho"
     a = A2.to_omega(x)
     assert a == Matrix([[2, -1]]) and a.basis == Basis.OMEGA
 
-    fw = A2.fundamental_weights[0]
+    fw = A2.fundamental_weights()[0]
     assert fw.basis == Basis.ORTHO
     assert A2.to_omega(fw) == Matrix([[1, 0]])
 
@@ -49,44 +51,38 @@ def test_A():
         Matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]),
         Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
     ]
-    assert A3.fundamental_weights == [
+    assert A3.fundamental_weights() == [
         Matrix([[Rational(3, 4), Rational(-1, 4), Rational(-1, 4), Rational(-1, 4)]]),
         Matrix([[Rational(1, 2), Rational(1, 2), Rational(-1, 2), Rational(-1, 2)]]),
         Matrix([[Rational(1, 4), Rational(1, 4), Rational(1, 4), Rational(-3, 4)]]),
     ]
 
     # backend
-    assert A3.root_system() == [
-        A3.to_ortho(x, "omega")
-        for x in [
-            Matrix([[1, 0, 1]]),
-            Matrix([[-1, 1, 1]]),
-            Matrix([[1, 1, -1]]),
-            Matrix([[-1, 2, -1]]),
-            Matrix([[0, -1, 2]]),
-            Matrix([[2, -1, 0]]),
-            Matrix([[0, 0, 0]]),
-            Matrix([[0, 0, 0]]),
-            Matrix([[0, 0, 0]]),
-            Matrix([[-2, 1, 0]]),
-            Matrix([[0, 1, -2]]),
-            Matrix([[1, -2, 1]]),
-            Matrix([[-1, -1, 1]]),
-            Matrix([[1, -1, -1]]),
-            Matrix([[-1, 0, -1]]),
-        ]
+    assert A3.root_system(basis="omega") == [
+        Matrix([[1, 0, 1]]),
+        Matrix([[-1, 1, 1]]),
+        Matrix([[1, 1, -1]]),
+        Matrix([[-1, 2, -1]]),
+        Matrix([[0, -1, 2]]),
+        Matrix([[2, -1, 0]]),
+        Matrix([[0, 0, 0]]),
+        Matrix([[0, 0, 0]]),
+        Matrix([[0, 0, 0]]),
+        Matrix([[-2, 1, 0]]),
+        Matrix([[0, 1, -2]]),
+        Matrix([[1, -2, 1]]),
+        Matrix([[-1, -1, 1]]),
+        Matrix([[1, -1, -1]]),
+        Matrix([[-1, 0, -1]]),
     ]
 
-    assert A3.positive_roots == [
-        A3.to_ortho(x, "omega")
-        for x in [
-            Matrix([[1, 0, 1]]),
-            Matrix([[-1, 1, 1]]),
-            Matrix([[1, 1, -1]]),
-            Matrix([[-1, 2, -1]]),
-            Matrix([[0, -1, 2]]),
-            Matrix([[2, -1, 0]]),
-        ]
+    assert A3.positive_roots(basis="ortho") == [
+        Matrix([[1, 0, 1]]),
+        Matrix([[-1, 1, 1]]),
+        Matrix([[1, 1, -1]]),
+        Matrix([[-1, 2, -1]]),
+        Matrix([[0, -1, 2]]),
+        Matrix([[2, -1, 0]]),
     ]
 
     fund = Matrix([[1, 0, 0]])
@@ -119,7 +115,7 @@ def test_A1():
     assert A1.dimension == 2
     assert A1.irrep_lookup("3") == Matrix([[2]])
     assert A1.root_system() == [
-        A1.to_ortho(x, "omega") for x in [Matrix([[2]]), Matrix([[0]]), Matrix([[-2]])]
+        x for x in [Matrix([[2]]), Matrix([[0]]), Matrix([[-2]])]
     ]
 
 
@@ -130,7 +126,7 @@ def test_B():
     assert B2.dimension == 2
     assert B2.n_pos_roots == 4
 
-    assert B2.simple_roots == [
+    assert B2.simple_roots() == [
         Matrix([[1, -1]]),
         Matrix([[0, 1]]),
     ]
@@ -143,7 +139,7 @@ def test_B():
     a = B2.to_omega(x)
     assert a == Matrix([[2, -2]]) and a.basis == Basis.OMEGA
 
-    fw = B2.fundamental_weights[0]
+    fw = B2.fundamental_weights()[0]
     assert fw.basis == Basis.ORTHO
     assert B2.to_omega(fw) == Matrix([[1, 0]])
 
@@ -162,7 +158,7 @@ def test_B():
         Matrix([[1, 0, 0], [0, 0, 1], [0, 1, 0]]),
         Matrix([[1, 0, 0], [0, 1, 0], [0, 0, -1]]),
     ]
-    assert B3.fundamental_weights == [
+    assert B3.fundamental_weights() == [
         Matrix([[1, 0, 0]]),
         Matrix([[1, 1, 0]]),
         Matrix([[Rational(1, 2), Rational(1, 2), Rational(1, 2)]]),
@@ -170,45 +166,39 @@ def test_B():
 
     # backend
     assert B3.root_system() == [
-        B3.to_ortho(x, "omega")
-        for x in [
-            Matrix([[0, 1, 0]]),
-            Matrix([[1, -1, 2]]),
-            Matrix([[-1, 0, 2]]),
-            Matrix([[1, 0, 0]]),
-            Matrix([[-1, 1, 0]]),
-            Matrix([[1, 1, -2]]),
-            Matrix([[-1, 2, -2]]),
-            Matrix([[0, -1, 2]]),
-            Matrix([[2, -1, 0]]),
-            Matrix([[0, 0, 0]]),
-            Matrix([[0, 0, 0]]),
-            Matrix([[0, 0, 0]]),
-            Matrix([[-2, 1, 0]]),
-            Matrix([[0, 1, -2]]),
-            Matrix([[1, -2, 2]]),
-            Matrix([[-1, -1, 2]]),
-            Matrix([[1, -1, 0]]),
-            Matrix([[-1, 0, 0]]),
-            Matrix([[1, 0, -2]]),
-            Matrix([[-1, 1, -2]]),
-            Matrix([[0, -1, 0]]),
-        ]
+        Matrix([[0, 1, 0]]),
+        Matrix([[1, -1, 2]]),
+        Matrix([[-1, 0, 2]]),
+        Matrix([[1, 0, 0]]),
+        Matrix([[-1, 1, 0]]),
+        Matrix([[1, 1, -2]]),
+        Matrix([[-1, 2, -2]]),
+        Matrix([[0, -1, 2]]),
+        Matrix([[2, -1, 0]]),
+        Matrix([[0, 0, 0]]),
+        Matrix([[0, 0, 0]]),
+        Matrix([[0, 0, 0]]),
+        Matrix([[-2, 1, 0]]),
+        Matrix([[0, 1, -2]]),
+        Matrix([[1, -2, 2]]),
+        Matrix([[-1, -1, 2]]),
+        Matrix([[1, -1, 0]]),
+        Matrix([[-1, 0, 0]]),
+        Matrix([[1, 0, -2]]),
+        Matrix([[-1, 1, -2]]),
+        Matrix([[0, -1, 0]]),
     ]
 
-    assert B3.positive_roots == [
-        B3.to_ortho(x, "omega")
-        for x in [
-            Matrix([[0, 1, 0]]),
-            Matrix([[1, -1, 2]]),
-            Matrix([[-1, 0, 2]]),
-            Matrix([[1, 0, 0]]),
-            Matrix([[-1, 1, 0]]),
-            Matrix([[1, 1, -2]]),
-            Matrix([[-1, 2, -2]]),
-            Matrix([[0, -1, 2]]),
-            Matrix([[2, -1, 0]]),
-        ]
+    assert B3.positive_roots() == [
+        Matrix([[0, 1, 0]]),
+        Matrix([[1, -1, 2]]),
+        Matrix([[-1, 0, 2]]),
+        Matrix([[1, 0, 0]]),
+        Matrix([[-1, 1, 0]]),
+        Matrix([[1, 1, -2]]),
+        Matrix([[-1, 2, -2]]),
+        Matrix([[0, -1, 2]]),
+        Matrix([[2, -1, 0]]),
     ]
 
     decomp = B3.tensor_product_decomposition(
@@ -244,7 +234,7 @@ def test_C():
     assert C2.dimension == 2
     assert C2.n_pos_roots == 4
 
-    assert C2.simple_roots == [
+    assert C2.simple_roots() == [
         Matrix([[1, -1]]),
         Matrix([[0, 2]]),
     ]
@@ -257,7 +247,7 @@ def test_C():
     a = C2.to_omega(x)
     assert a == Matrix([[2, -1]]) and a.basis == Basis.OMEGA
 
-    fw = C2.fundamental_weights[0]
+    fw = C2.fundamental_weights()[0]
     assert fw.basis == Basis.ORTHO
     assert C2.to_omega(fw) == Matrix([[1, 0]])
 
@@ -278,7 +268,7 @@ def test_C():
         Matrix([[1, 0, 0], [0, 0, 1], [0, 1, 0]]),
         Matrix([[1, 0, 0], [0, 1, 0], [0, 0, -1]]),
     ]
-    assert C3.fundamental_weights == [
+    assert C3.fundamental_weights() == [
         Matrix([[1, 0, 0]]),
         Matrix([[1, 1, 0]]),
         Matrix([[1, 1, 1]]),
@@ -308,7 +298,7 @@ def test_C():
         Matrix([[-2, 0, 0]]),
     ]
 
-    assert [C3.to_omega(x) for x in C3.positive_roots] == [
+    assert [C3.to_omega(x) for x in C3.positive_roots()] == [
         Matrix([[2, 0, 0]]),
         Matrix([[0, 1, 0]]),
         Matrix([[-2, 2, 0]]),
@@ -333,7 +323,7 @@ def test_D():
     assert D2.dimension == 2
     assert D2.n_pos_roots == 2
 
-    assert D2.simple_roots == [
+    assert D2.simple_roots() == [
         Matrix([[1, -1]]),
         Matrix([[1, 1]]),
     ]
@@ -346,7 +336,7 @@ def test_D():
     a = D2.to_omega(x)
     assert a == Matrix([[2, 0]]) and a.basis == Basis.OMEGA
 
-    fw = D2.fundamental_weights[0]
+    fw = D2.fundamental_weights()[0]
     assert fw.basis == Basis.ORTHO
     assert D2.to_omega(fw) == Matrix([[1, 0]])
 
@@ -373,7 +363,7 @@ def test_D():
         Matrix([[1, 0, 0], [0, 0, 1], [0, 1, 0]]),
         Matrix([[1, 0, 0], [0, 0, -1], [0, -1, 0]]),
     ]
-    assert D3.fundamental_weights == [
+    assert D3.fundamental_weights() == [
         Matrix([[1, 0, 0]]),
         Matrix([[Rational(1, 2), Rational(1, 2), Rational(-1, 2)]]),
         Matrix([[Rational(1, 2), Rational(1, 2), Rational(1, 2)]]),
@@ -398,7 +388,7 @@ def test_D():
         Matrix([[0, -1, -1]]),
     ]
 
-    assert [D3.to_omega(x) for x in D3.positive_roots] == [
+    assert [D3.to_omega(x) for x in D3.positive_roots()] == [
         Matrix([[0, 1, 1]]),
         Matrix([[1, -1, 1]]),
         Matrix([[1, 1, -1]]),

--- a/tests/test_algebra/test_exceptionals.py
+++ b/tests/test_algebra/test_exceptionals.py
@@ -9,14 +9,14 @@ def test_F4():
     assert F4_.dimension == 4
     assert F4_.n_pos_roots == 24
 
-    assert F4_.simple_roots == [
+    assert F4_.simple_roots() == [
         Matrix([[1, -1, 0, 0]]),
         Matrix([[0, 1, -1, 0]]),
         Matrix([[0, 0, 1, 0]]),
         Matrix([[-S.Half, -S.Half, -S.Half, -S.Half]]),
     ]
 
-    fw = F4_.fundamental_weights[0]
+    fw = F4_.fundamental_weights()[0]
     assert fw.basis == Basis.ORTHO
     assert F4_.to_omega(fw) == Matrix([[1, 0, 0, 0]])
 
@@ -51,7 +51,7 @@ def test_F4():
             ]
         ),
     ]
-    assert F4_.fundamental_weights == [
+    assert F4_.fundamental_weights() == [
         Matrix([[1, 0, 0, -1]]),
         Matrix([[1, 1, 0, -2]]),
         Matrix([[S.Half, S.Half, S.Half, -3 * S.Half]]),
@@ -122,7 +122,7 @@ def test_E6():
     assert E6.dimension == 6
     assert E6.n_pos_roots == 36
 
-    assert E6.simple_roots == [
+    assert E6.simple_roots() == [
         Matrix(
             [[S.Half, -S.Half, -S.Half, -S.Half, -S.Half, -S.Half, -S.Half, S.Half]]
         ),
@@ -133,7 +133,7 @@ def test_E6():
         Matrix([[1, 1, 0, 0, 0, 0, 0, 0]]),
     ]
 
-    fw = E6.fundamental_weights[0]
+    fw = E6.fundamental_weights()[0]
     assert fw.basis == Basis.ORTHO
     assert E6.to_omega(fw) == Matrix([[1, 0, 0, 0, 0, 0]])
 
@@ -270,7 +270,7 @@ def test_E6():
         Matrix([[0, 0, 0, 0, 0, -1]]),
     ]
 
-    assert [E6.to_omega(x) for x in E6.positive_roots] == [
+    assert [E6.to_omega(x) for x in E6.positive_roots()] == [
         Matrix([[0, 0, 0, 0, 0, 1]]),
         Matrix([[0, 0, 1, 0, 0, -1]]),
         Matrix([[0, 1, -1, 1, 0, 0]]),

--- a/tests/test_group/test_liegroup.py
+++ b/tests/test_group/test_liegroup.py
@@ -50,7 +50,7 @@ def test_so():
 
     for n in range(5, 7):
         g = SO(n)
-        r = g.algebra.fundamental_weights[0]
+        r = g.algebra.fundamental_weights()[0]
         assert g.quadratic_casimir(r) == sympify(n - 1) / 2
 
 
@@ -66,5 +66,5 @@ def test_sp():
 
     for n in range(2, 5):
         g = Sp(2 * n)
-        r = g.algebra.fundamental_weights[0]
+        r = g.algebra.fundamental_weights()[0]
         assert g.quadratic_casimir(r) == sympify(2 * n + 1) / 2


### PR DESCRIPTION
Previous implementations had `root_system`, `simple_roots`, `positive_roots`  and `fundamental_weights` on the algebras were properties. This required casting them to different supported basis cumbersome using a `to_omega` type method for example. These are all now `lru_cached` methods that take `basis` as an arg. This should make it easier move between the supported basis. Additionally, to set you own initial orthogonal basis, the constructor now takes simple_roots as an optional arg.

Also added caching to various methods,