### PR TITLE
Expanding type hints

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,12 @@
+
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ env:
   SPHINX_BUILD: "1"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   linux:

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ config.toml
 *.npy
 docsrc/_build
 notesbooks/Notebook.ipynb
+.dmypy.json
+typings

--- a/liesym/__init__.py
+++ b/liesym/__init__.py
@@ -1,7 +1,9 @@
 import os
 
 try:
-    from ._liesym_rust import LieAlgebraBackend as _LieAlgebraBackend
+    from ._liesym_rust import (  # type: ignore[import-untyped]
+        LieAlgebraBackend as _LieAlgebraBackend,
+    )
 except ImportError:
     # suppress import error during sphinx builds
     if os.environ.get("SPHINX_BUILD") != "1":

--- a/liesym/algebras/__init__.py
+++ b/liesym/algebras/__init__.py
@@ -1,4 +1,4 @@
-from ._base import Basis, LieAlgebra, NumericSymbol
+from ._base import Basis, BASIS, LieAlgebra, NumericSymbol
 from ._classic import A, B, C, D
 from ._exceptionals import E, F4, G2
 from ._methods import root_angle
@@ -15,4 +15,5 @@ __all__ = [
     "NumericSymbol",
     "Basis",
     "root_angle",
+    "BASIS",
 ]

--- a/liesym/algebras/_classic.py
+++ b/liesym/algebras/_classic.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from sympy import flatten, Matrix
 from sympy.core.sympify import _sympify
 
@@ -23,7 +25,7 @@ class A(LieAlgebra):
 
     """
 
-    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+    def __new__(cls, n: int, simple_roots: Optional[List[Matrix]] = None):
         """Creates the A algebra of rank `n`
 
         Args:
@@ -90,7 +92,7 @@ class B(LieAlgebra):
 
     """
 
-    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+    def __new__(cls, n: int, simple_roots: Optional[List[Matrix]] = None):
         """Creates the B algebra of dimension `n`
 
         Args:
@@ -141,7 +143,7 @@ class C(LieAlgebra):
        :align: center
     """
 
-    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+    def __new__(cls, n: int, simple_roots: Optional[List[Matrix]] = None):
         """Creates the C algebra of dimension `n`
 
         Args:
@@ -150,6 +152,8 @@ class C(LieAlgebra):
             calculating the algebra in a different basis. Defaults to None.
 
         """
+        if not isinstance(n, int):
+            n = int(n)
         if simple_roots is None:
             c_root = [0] * n
             c_root[-1] = 2
@@ -195,7 +199,7 @@ class D(LieAlgebra):
        :align: center
     """
 
-    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+    def __new__(cls, n: int, simple_roots: Optional[List[Matrix]] = None):
         """Creates the D algebra of dimension `n`
 
         Args:

--- a/liesym/algebras/_exceptionals.py
+++ b/liesym/algebras/_exceptionals.py
@@ -1,5 +1,8 @@
+from typing import List, Optional
+
 from sympy import flatten, Matrix, S
 from sympy.core.sympify import _sympify
+
 from ._base import LieAlgebra
 
 
@@ -11,8 +14,8 @@ class F4(LieAlgebra):
        :align: center
 
     """
-    
-    def __new__(cls, simple_roots: "list[Matrix] | None" = None):
+
+    def __new__(cls, simple_roots: Optional[List[Matrix]] = None):
         """Creates the F4 algebra
         Args:
             simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
@@ -23,12 +26,13 @@ class F4(LieAlgebra):
             cls,
             "F",
             _sympify(4),
-            simple_roots or [
-            Matrix([[1, -1, 0, 0]]),
-            Matrix([[0, 1, -1, 0]]),
-            Matrix([[0, 0, 1, 0]]),
-            Matrix([[-S.Half, -S.Half, -S.Half, -S.Half]]),
-        ],
+            simple_roots
+            or [
+                Matrix([[1, -1, 0, 0]]),
+                Matrix([[0, 1, -1, 0]]),
+                Matrix([[0, 0, 1, 0]]),
+                Matrix([[-S.Half, -S.Half, -S.Half, -S.Half]]),
+            ],
         )
 
     @property
@@ -53,7 +57,8 @@ class G2(LieAlgebra):
        :align: center
 
     """
-    def __new__(cls, simple_roots: "list[Matrix] | None" = None):
+
+    def __new__(cls, simple_roots: Optional[List[Matrix]] = None):
         """Creates the G2 algebra
         Args:
             simple_roots (list[Matrix] | None, optional): Overrides default simple roots. Use this for
@@ -64,7 +69,7 @@ class G2(LieAlgebra):
             cls,
             "G",
             _sympify(2),
-            simple_roots or [Matrix([[0, 1, -1]]), Matrix([[1, -2, 1]])]
+            simple_roots or [Matrix([[0, 1, -1]]), Matrix([[1, -2, 1]])],
         )
 
     @property
@@ -123,7 +128,8 @@ class E(LieAlgebra):
            E8
 
     """
-    def __new__(cls, n: int, simple_roots: "list[Matrix] | None" = None):
+
+    def __new__(cls, n: int, simple_roots: Optional[List[Matrix]] = None):
         """Creates the E algebra of rank `n`
 
         Args:
@@ -136,10 +142,7 @@ class E(LieAlgebra):
             raise ValueError("Algebra series E only defined for 6, 7 and 8")
 
         return super().__new__(
-            cls,
-            "E",
-            _sympify(n),
-            simple_roots or _e_series_default_roots(n)
+            cls, "E", _sympify(n), simple_roots or _e_series_default_roots(n)
         )
 
     @property

--- a/liesym/groups/_cyclic.py
+++ b/liesym/groups/_cyclic.py
@@ -1,5 +1,7 @@
-# from __future__ import annotations
+from __future__ import annotations
+
 from functools import reduce
+from typing import List, Literal, overload, Tuple, Union
 
 from sympy import conjugate, exp, I, pi, Symbol
 
@@ -17,7 +19,15 @@ class Z(Group):
             Symbol(f"Z_{idx}"): x for idx, x in enumerate(self.generators())
         }
 
-    def generators(self, indexed=False) -> list:
+    @overload
+    def generators(self, indexed: Literal[False] = False) -> List[exp]:
+        ...
+
+    @overload
+    def generators(self, indexed: Literal[True]) -> List[Tuple[Symbol, exp]]:
+        ...
+
+    def generators(self, indexed: bool = False):
         """The basis for the generators in the cyclic group are
         in the exponential imaginary basis.
 
@@ -35,16 +45,27 @@ class Z(Group):
         """
         d = self.dimension
 
-        gens = [exp(2 * pi * I * x / d) for x in range(d)]
+        gens = [
+            exp(2 * pi * I * x / d) for x in range(int(d))
+        ]  # type:ignore[call-overload]
         if indexed:
             return [(Symbol(f"Z_{idx}"), x) for idx, x in enumerate(gens)]
         return gens
 
-    def product(self, *args, **kwargs) -> list:
+    @overload
+    def product(self, as_tuple: Literal[False] = False) -> List[exp]:
+        ...
+
+    @overload
+    def product(self, as_tuple: Literal[True]) -> List[Tuple[Symbol, exp]]:
+        ...
+
+    def product(self, *args: Union[str, Symbol], as_tuple=False):
         """Product of the Cyclic representations
 
-        Returns:
-            list: To keep types standard, returns a list of length 1
+        Args:
+            args: A list of args to take product of
+            as_tuple (bool, optional): Returns a tuple of their symbolic rep and exp val instead of just exp val
 
         Examples
         ========
@@ -53,32 +74,22 @@ class Z(Group):
         >>> g = z5.generators()
         >>> z5.product(g[0], g[1], g[2], g[3], g[4])
         [1]
-        """
-        return [reduce(lambda a, b: a * b, args)]
-
-    def sym_product(self, *args, as_tuple=False, **kwargs) -> list:
-        """Will take the product symbolically of Cyclic representations
-        of the form `lambda x: f`Z_{x}`
-
-        Returns:
-            list: To keep types standard, returns a list of length 1
-
-        Examples
-        ========
-        >>> from liesym import Z
-        >>> z5 = Z(5)
-        >>> z5.sym_product("Z_1", "Z_2")
+        >>> z5.product("Z_1", "Z_2")
         [Z_3]
-        >>> z5.sym_product("Z_3", "Z_4", as_tuple=True)
+        >>> z5.product("Z_3", "Z_4", as_tuple=True)
         [(Z_2, exp(4*I*pi/5))]
         """
-
-        cleaned_args = [Symbol(x) if isinstance(x, str) else x for x in args]
-
-        result = self.product(*[self._lookups[x] for x in cleaned_args])
-
+        if all([isinstance(x, Symbol) for x in args]):
+            results = [reduce(lambda a, b: a * b, [self._lookups[x] for x in args])]
+        elif all([isinstance(x, str) for x in args]):
+            args = [Symbol(x) for x in args]  # type: ignore[assignment]
+            results = self.product(*args)
+        elif all([hasattr(x, "__mul__") for x in args]):
+            results = [reduce(lambda a, b: a * b, args)]  # type: ignore
+        else:
+            raise TypeError("Unsupported type of args, please use string or symbol or exp")
         for k, v in self._lookups.items():
-            if v == result[0]:
+            if v == results[0] or k == results[0]:
                 if as_tuple:
                     return [(k, v)]
                 return [k]

--- a/liesym/groups/_so.py
+++ b/liesym/groups/_so.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Union
+from typing import List, Literal, overload, Tuple, Union
 
 from sympy import I, KroneckerDelta, Matrix, zeros
 
@@ -26,9 +26,21 @@ class SO(LieGroup):
         else:
             self._algebra = B((n - 1) / 2)
 
+    @overload
     def generators(
-        self, cartan_only=False, indexed=False
-    ) -> list[Union[Matrix, Tuple[Matrix, tuple]]]:
+        self, *, cartan_only: bool = False, indexed: Literal[True]
+    ) -> List[Tuple[Matrix, tuple]]:
+        ...
+
+    @overload
+    def generators(
+        self, cartan_only: bool = False, indexed: Literal[False] = False
+    ) -> List[Matrix]:
+        ...
+
+    def generators(
+        self, cartan_only: bool = False, indexed: bool = False
+    ) -> Union[List[Matrix], List[Tuple[Matrix, tuple]]]:
         """Generators for SO(N).
 
         Args:

--- a/liesym/groups/_su.py
+++ b/liesym/groups/_su.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Generator
 
-from sympy import Basic, I
+from sympy import I
 from sympy.core.backend import sqrt, zeros
 
 from ..algebras import A
@@ -25,6 +25,8 @@ def generalized_gell_mann(dimension: int) -> Generator:
         - https://mathworld.wolfram.com/GeneralizedGell-MannMatrix.html
 
     """
+    if not isinstance(dimension, int):
+        dimension = int(dimension)
 
     def eij(dim):
         def _(i, j):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1412,6 +1412,53 @@ gmpy = ["gmpy2 (>=2.1.0a4)"]
 tests = ["pytest (>=4.6)"]
 
 [[package]]
+name = "mypy"
+version = "1.7.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5da84d7bf257fd8f66b4f759a904fd2c5a765f70d8b52dde62b521972a0a2357"},
+    {file = "mypy-1.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a3637c03f4025f6405737570d6cbfa4f1400eb3c649317634d273687a09ffc2f"},
+    {file = "mypy-1.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b633f188fc5ae1b6edca39dae566974d7ef4e9aaaae00bc36efe1f855e5173ac"},
+    {file = "mypy-1.7.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d6ed9a3997b90c6f891138e3f83fb8f475c74db4ccaa942a1c7bf99e83a989a1"},
+    {file = "mypy-1.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:1fe46e96ae319df21359c8db77e1aecac8e5949da4773c0274c0ef3d8d1268a9"},
+    {file = "mypy-1.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:df67fbeb666ee8828f675fee724cc2cbd2e4828cc3df56703e02fe6a421b7401"},
+    {file = "mypy-1.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a79cdc12a02eb526d808a32a934c6fe6df07b05f3573d210e41808020aed8b5d"},
+    {file = "mypy-1.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f65f385a6f43211effe8c682e8ec3f55d79391f70a201575def73d08db68ead1"},
+    {file = "mypy-1.7.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0e81ffd120ee24959b449b647c4b2fbfcf8acf3465e082b8d58fd6c4c2b27e46"},
+    {file = "mypy-1.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:f29386804c3577c83d76520abf18cfcd7d68264c7e431c5907d250ab502658ee"},
+    {file = "mypy-1.7.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:87c076c174e2c7ef8ab416c4e252d94c08cd4980a10967754f91571070bf5fbe"},
+    {file = "mypy-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6cb8d5f6d0fcd9e708bb190b224089e45902cacef6f6915481806b0c77f7786d"},
+    {file = "mypy-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d93e76c2256aa50d9c82a88e2f569232e9862c9982095f6d54e13509f01222fc"},
+    {file = "mypy-1.7.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cddee95dea7990e2215576fae95f6b78a8c12f4c089d7e4367564704e99118d3"},
+    {file = "mypy-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:d01921dbd691c4061a3e2ecdbfbfad029410c5c2b1ee88946bf45c62c6c91210"},
+    {file = "mypy-1.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:185cff9b9a7fec1f9f7d8352dff8a4c713b2e3eea9c6c4b5ff7f0edf46b91e41"},
+    {file = "mypy-1.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7a7b1e399c47b18feb6f8ad4a3eef3813e28c1e871ea7d4ea5d444b2ac03c418"},
+    {file = "mypy-1.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc9fe455ad58a20ec68599139ed1113b21f977b536a91b42bef3ffed5cce7391"},
+    {file = "mypy-1.7.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d0fa29919d2e720c8dbaf07d5578f93d7b313c3e9954c8ec05b6d83da592e5d9"},
+    {file = "mypy-1.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b53655a295c1ed1af9e96b462a736bf083adba7b314ae775563e3fb4e6795f5"},
+    {file = "mypy-1.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c1b06b4b109e342f7dccc9efda965fc3970a604db70f8560ddfdee7ef19afb05"},
+    {file = "mypy-1.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bf7a2f0a6907f231d5e41adba1a82d7d88cf1f61a70335889412dec99feeb0f8"},
+    {file = "mypy-1.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:551d4a0cdcbd1d2cccdcc7cb516bb4ae888794929f5b040bb51aae1846062901"},
+    {file = "mypy-1.7.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:55d28d7963bef00c330cb6461db80b0b72afe2f3c4e2963c99517cf06454e665"},
+    {file = "mypy-1.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:870bd1ffc8a5862e593185a4c169804f2744112b4a7c55b93eb50f48e7a77010"},
+    {file = "mypy-1.7.0-py3-none-any.whl", hash = "sha256:96650d9a4c651bc2a4991cf46f100973f656d69edc7faf91844e87fe627f7e96"},
+    {file = "mypy-1.7.0.tar.gz", hash = "sha256:1e280b5697202efa698372d2f39e9a6713a0395a756b1c6bd48995f8d72690dc"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1710,13 +1757,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
+version = "4.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
+    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
 ]
 
 [package.extras]
@@ -1754,13 +1801,13 @@ twisted = ["twisted"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.39"
+version = "3.0.40"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.39-py3-none-any.whl", hash = "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"},
-    {file = "prompt_toolkit-3.0.39.tar.gz", hash = "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac"},
+    {file = "prompt_toolkit-3.0.40-py3-none-any.whl", hash = "sha256:99ba3dfb23d5b5af89712f89e60a5f3d9b8b67a9482ca377c5771d0e9047a34b"},
+    {file = "prompt_toolkit-3.0.40.tar.gz", hash = "sha256:a371c06bb1d66cd499fecd708e50c0b6ae00acba9822ba33c586e2f16d1b739e"},
 ]
 
 [package.dependencies]
@@ -3027,4 +3074,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "b066a0063683a4be7d82ef68868fb091fdcf172804920f629a0f84d3e3839802"
+content-hash = "592b98e8d496b92dc5e6f95ff44a1659bd3ac68ff2101a5b683bf9222782a732"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ maturin = ">=1.3"
 setuptools = ">=60"
 tomlkit = ">=0.12"
 yq = ">=3.2"
+mypy = ">=1.7.0"
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = ">=5"
@@ -37,10 +38,11 @@ numpydoc = ">=1.1.0"
 pydata_sphinx_theme = ">=0.14.2"
 sphinx-math-dollar = ">=1.2"
 
+
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 testpaths = ["tests"]
-pythonpath = ["liesym"]
+
 
 [project]
 classifiers = ["Topic :: Scientific/Engineering :: Mathematics", "Topic :: Scientific/Engineering :: Physics", "Programming Language :: Rust", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11"]
@@ -57,3 +59,5 @@ email = "npapapietro95@gmail.com"
 [project.urls]
 Documentation = "https://npapapietro.github.io/liesym"
 Homepage = "https://github.com/npapapietro/liesym"
+
+

--- a/tests/test_algebra/test_classic.py
+++ b/tests/test_algebra/test_classic.py
@@ -87,7 +87,7 @@ def test_A():
 
     fund = Matrix([[1, 0, 0]])
     antifund = Matrix([[0, 0, 1]])
-    decomp = A3.tensor_product_decomposition([fund, antifund])
+    decomp = A3.tensor_product_decomposition(fund, antifund)
 
     assert set([x.as_immutable() for x in decomp]) == set(
         [
@@ -202,7 +202,7 @@ def test_B():
     ]
 
     decomp = B3.tensor_product_decomposition(
-        [Matrix([[1, 0, 0]]), Matrix([[1, 0, 0]]), Matrix([[1, 0, 0]])]
+        Matrix([[1, 0, 0]]), Matrix([[1, 0, 0]]), Matrix([[1, 0, 0]])
     )
     assert sorted([tuple(x.tolist()) for x in decomp]) == sorted(
         [

--- a/tests/test_group/test_cyclic.py
+++ b/tests/test_group/test_cyclic.py
@@ -7,10 +7,10 @@ def test_z():
 
     g = z5.generators()
 
-    assert [1] == z5.product(*g)
+    assert 1 == z5.product(*g, as_tuple=True)[0][1]
 
-    assert [Symbol("Z_3")] == z5.sym_product("Z_1", "Z_2")
+    assert [Symbol("Z_3")] == z5.product("Z_1", "Z_2")
 
-    assert [(Symbol("Z_2"), exp(4 * I * pi / 5))] == z5.sym_product(
+    assert [(Symbol("Z_2"), exp(4 * I * pi / 5))] == z5.product(
         "Z_3", "Z_4", as_tuple=True
     )


### PR DESCRIPTION
Smarter type hints for mypy users

Breaking Changes:
 -  method on groups `sym_product` is removed in favor of type checking args for `product`